### PR TITLE
[NCL-8001] Produce pnc-common jar with jakarta annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,19 @@ Maven project's pom.xml:
 </dependency>
 ```
 
+Using the Eclipse Transformer Maven plugin, we also produce a jar with Jakarta
+annotations. You can consume it in your project as:
+```
+<dependency>
+  <groupId>org.jboss.pnc</groupId>
+  <artifactId>pnc-common</artifactId>
+  <version>LATEST_VERSION</version>
+  <classifier>jakarta</classifier>
+</dependency>
+```
+
+Once we migrate all of our annotations / classes from `javax` to `jakarta`, the
+classifier won't be needed anymore.
+
 The latest version is specified [here](https://repo1.maven.org/maven2/org/jboss/pnc/pnc-common/maven-metadata.xml)
 Snapshot versions are published [here](https://repository.jboss.org/org/jboss/pnc/pnc-common/)

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,33 @@
               </executions>
             </plugin>
             <plugin>
+                <groupId>org.eclipse.transformer</groupId>
+                <artifactId>transformer-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <rules>
+                        <jakartaDefaults>true</jakartaDefaults>
+                    </rules>
+                    <classifier>jakarta</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                            </artifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>


### PR DESCRIPTION
This is done using the Eclipse Transformer Maven plugin. We run the default jar through the plugin to spit out the jar with classifier jakarta.

You can then consume either the `javax` jar (default) or the `jakarta` jar (with classifier jakarta) in your project.